### PR TITLE
`refactor`: rename project to SplitScale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# SOPHOS Relay
-Bypass SOPHOS over Tailscale intelligently
+# SplitScale
+A Split Tunneling Solution through Tailscale based on domain matching
 
 ### Prerequisites (will be covered in Instructions):
 - A Tailscale Account
@@ -21,7 +21,7 @@ Bypass SOPHOS over Tailscale intelligently
 - Prepare to configure one of the devices as an exit-node by running `tailscale up --advertise-exit-node`, then allow the exit-node request of the device from the [admin console](https://login.tailscale.com/admin/machines), by clicking the `ellipsis icon menu` of the exit node device, then open the `Edit route` settings panel, and enable `Use as exit node`. Refer to [Advertise a device as an exit node](https://tailscale.com/kb/1103/exit-nodes#advertise-a-device-as-an-exit-node) section and [Allow the exit node from the admin console](https://tailscale.com/kb/1103/exit-nodes#allow-the-exit-node-from-the-admin-console) for more info.
 - Clone this repository:
   ```bash
-  git clone https://github.com/sannidhyaroy/SOPHOS-Relay
+  git clone https://github.com/sannidhyaroy/SplitScale.git
   ```
 - Install Flask, if it is not installed already:
   ```bash
@@ -51,14 +51,14 @@ Bypass SOPHOS over Tailscale intelligently
     ```
 - Run the daemon temporarily by running `python <directory to daemon.py>`. Or, you can run it as a proper daemon, detached from the console, by following [this article](https://medium.com/@guemandeuhassler96/run-your-python-script-as-a-linux-daemon-9a82ed427c1a). Since, this project isn't stable for production, we'll run the daemon temporarily inside our terminal, that can be stopped with `Ctrl/Cmd + C`. You can deactivate Python Virtual Environment after stopping the daemon by running `deactivate`.
 - Open you browser (based on Chromium), navigate to `chrome://extensions` (browsers may rewrite the url as necessary, if it isn't Chrome). Then turn on `Developer Mode` toggle and click `Load Unpacked`. Choose the `extensions` directory inside this repository.
-- Navigate to the `SOPHOS Relay` Extension Settings Page and map required domains to an exit-node IP. You can obtain the exit-node IP address of a device by running `tailscale status` and noting down the IP of the device advertising as exit node.
+- Navigate to the `SplitScale` Extension Settings Page and map required domains to an exit-node IP. You can obtain the exit-node IP address of a device by running `tailscale status` and noting down the IP of the device advertising as exit node.
 - Try testing by going to one of the configured domains and the extension should sent a request to the daemon process to use the configured device as an exit-node.
 ---
 
 ### Privacy Considerations:
-- SOPHOS Relay is fully open-source, licensed under the [GNU Affero General Public License (AGPL) v3.0](https://github.com/sannidhyaroy/SOPHOS-Relay/blob/main/LICENSE). We are in no way affiliated to or partnered with Tailscale.
+- SplitScale is fully open-source, licensed under the [GNU Affero General Public License (AGPL) v3.0](https://github.com/sannidhyaroy/SplitScale/blob/main/LICENSE). We are in no way affiliated to or partnered with Tailscale.
 - Tailscale is a partially open-source tool with some proprietary components, such as the Tailscale Coordination Server. Our project works with Tailscale’s existing setup and does not modify or distribute Tailscale’s proprietary software. Users must comply with Tailscale’s terms of service and licensing. For a fully open-source alternative to Tailscale’s coordination server, users might consider using [Headscale](https://github.com/juanfont/headscale). The instructions provided for this project assumes you're using the default Tailscale Coordination Server and their official client apps or cli, but it should work with Headscale as well. Read more at ["Open-Source at Tailscale"](https://tailscale.com/opensource).
 ---
 
 ### License
-SOPHOS Relay is licensed under the [GNU Affero General Public License (AGPL) v3.0](https://github.com/sannidhyaroy/SOPHOS-Relay/blob/main/LICENSE)
+SplitScale is licensed under the [GNU Affero General Public License (AGPL) v3.0](https://github.com/sannidhyaroy/SplitScale/blob/main/LICENSE).

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "name": "SOPHOS Relay",
+  "name": "SplitScale",
   "version": "1.1",
   "permissions": ["webRequest", "webRequestBlocking", "storage", "activeTab", "<all_urls>"],
   "background": {
@@ -8,7 +8,7 @@
   },
   "browser_action": {
     "default_popup": "popup.html",
-    "default_title": "SOPHOS Relay"
+    "default_title": "SplitScale"
   },
   "options_page": "settings.html"
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,27 +1,32 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>SOPHOS Relay</title>
+    <title>SplitScale</title>
     <style>
+        :root {
+            color: white;
+            background-color: black;
+        }
         body { 
             font-family: Arial, sans-serif; 
             text-align: center; 
             width: 200px;
             padding: 10px;
         }
-        img {
-            width: 48px;
-            cursor: pointer;
-        }
         #settingsIcon {
             margin-top: 20px;
+            width: 48px;
+            cursor: pointer;
         }
     </style>
 </head>
 <body>
-    <h3>SOPHOS Relay</h3>
-    <p>Bypass SOPHOS over Tailscale intelligently</p>
-    <img id="settingsIcon" src="settings-icon.png" alt="Settings Icon" />
+    <h3>SplitScale</h3>
+    <p>A Split Tunneling Solution through Tailscale based on domain matching</p>
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" id="settingsIcon" class="bi bi-gear" alt="Settings" viewBox="0 0 16 16">
+        <path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492M5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0"/>
+        <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159a.873.873 0 0 1-1.255-.52zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 0 0 2.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 0 0 1.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 0 0-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 0 0-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 0 0-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 0 0 1.945 8.93l-.319-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 0 0 3.06 4.377l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 0 0 2.692-1.115z"/>
+    </svg>
     <script src="popup.js"></script>
 </body>
 </html>

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -1,17 +1,35 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Settings - SOPHOS Relay</title>
+    <title>Settings - SplitScale</title>
     <style>
-        body { font-family: Arial, sans-serif; }
-        #domainList { margin-top: 20px; }
-        .domain-item { margin-bottom: 10px; }
+        :root {
+            color: white;
+            background-color: black;
+        }
+        body {
+            font-family: Arial, sans-serif;
+        }
+        input, button {
+            padding: 0.5em;
+            color: white;
+            background-color: #2e2e2e;
+        }
+        #domainList {
+            margin-top: 20px;
+        }
+        .domain-item {
+            margin-bottom: 10px;
+        }
     </style>
 </head>
 <body>
-    <h1>SOPHOS Relay Settings</h1>
+    <h1>SplitScale Settings</h1>
     <div>
         <input id="domain" placeholder="Enter domain" type="text" />
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-right-short" viewBox="0 0 16 16">
+            <path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8"/>
+        </svg>
         <input id="exitNode" placeholder="Enter exit node IP" type="text" />
         <button id="add">Add</button>
     </div>

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -11,7 +11,11 @@ function loadDomainList() {
             const div = document.createElement('div');
             div.className = 'domain-item';
             div.innerHTML = `
-                <span>${domain} → ${exitNode}</span>
+                <span>${domain}
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-right-short" viewBox="0 0 16 16">
+                        <path fill-rule="evenodd" d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8"/>
+                    </svg>
+                ${exitNode}</span>
                 <button class="remove" data-domain="${domain}">Remove</button>
             `;
             domainList.appendChild(div);


### PR DESCRIPTION
### This PR renames the project to SplitScale.

It also includes some minor fixes as follows:
- Replaced broken icons with SVGs.
- Dark Theming by default